### PR TITLE
multi-hal: Convert: add LIGHT and PRESSURE

### DIFF
--- a/multi-hal/Convert.cpp
+++ b/multi-hal/Convert.cpp
@@ -289,6 +289,10 @@ void convertFromSTMSensorData(const ::stm::core::ISTMSensorsCallbackData& sensor
         event.u.uncal.y_bias = sensorData.getData().at(4);
         event.u.uncal.z_bias = sensorData.getData().at(5);
         break;
+    case SensorType::LIGHT:
+    case SensorType::PRESSURE:
+        event.u.scalar = sensorData.getData().at(0);
+        break;
     case SensorType::META_DATA:
         event.u.meta.what = V1_0::MetaDataEventType::META_DATA_FLUSH_COMPLETE;
         break;


### PR DESCRIPTION
convertFromSTMSensorData() doesn't currently support light nor pressure events. With this patch, it's possible for Android to receive both events; otherwise, they're completely blocked.

I understand you may have a gerrit based review, so feel free to discard this if it doesn't fit your criteria.